### PR TITLE
Allow configuring default menu sets in yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,16 @@ There are 2 main steps to creating a menu using menu management.
 
 ### Creating a MenuSet
 
-This is pretty straight forward. You just give the MenuSet a Name (which is what
-you reference in the templates when controlling the menu)
+This is pretty straight forward. You just give the MenuSet a Name (which is what you reference in the templates when controlling the menu).
+
+As it is common to reference MenuSets by name in templates, you can configure sets to be created automatically during the /dev/build task. These sets cannot be deleted through the CMS.
+
+```yaml
+MenuSet:
+  default_sets:
+    - Main
+    - Footer
+```
 
 
 ### Creating MenuItems


### PR DESCRIPTION
It's very common to hard code menu set names into templates. In the past, MenuSet records have been created manually in the CMS. Since this only needs to happen once, it's not really a problem, but it's a little untidy. This change guarantees that configured menu set names will exist (after a dev-build), and prevents the user from deleting them.

Config example:

```yaml
MenuSet:
  default_sets:
    - Main
    - Footer
```
Resolves #8