### PR TITLE
FIX: Don’t copy ID from target page on write

### DIFF
--- a/code/MenuItem.php
+++ b/code/MenuItem.php
@@ -133,7 +133,7 @@ class MenuItem extends DataObject implements PermissionProvider
     {
         $default = parent::__get($field);
 
-        if ($default) {
+        if ($default || $field === 'ID') {
             return $default;
         } else {
             $page = $this->Page();


### PR DESCRIPTION
Changes in `DataObject::write()` for 3.2 highlighted this issue.

`DataObject::write()` uses `isInDB()` which will check for an ID. If adding a new menu item, the ID is not set and it will be copied from the target page, resulting in SilverStripe trying to write to a row with the page’s ID instead of creating a new row.

This didn’t happen in 3.1 because `DataObject::write()` would [access `$this->record['ID']` directly](https://github.com/silverstripe/silverstripe-framework/blob/3.1/model/DataObject.php#L1209), bypassing `__get()`.