### PR TITLE
Update composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0",
-		"silverstripe-australia/gridfieldextensions": "~1.3.0"
+		"silverstripe/framework": "~3.1",
+		"silverstripe-australia/gridfieldextensions": "^1.3.0"
 	},
 	"extra": {
 		"dev-master": "2.1.x-dev"


### PR DESCRIPTION
Rationale:

- The `gridfieldextensions` module is semantically versioned, so the less restrictive `^1.3.0` will allow newer versions.
- `"silverstripe-australia/gridfieldextensions": "^1.3.0"` (the old requirement) already requires `"silverstripe/framework": "~3.1"`, so this doesn’t change anything
- Framework will pull in `composer/installers` anyway, and this module doesn’t explicitly require it