### PR TITLE
Fetch all and sort menu sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ MenuSet:
     - Footer
 ```
 
+### Allow sorting of MenuSets
+
+By default menu sets cannot be sorted, however, you can set your configuration to allow it.
+
+```yaml
+MenuSet:
+  allow_sorting: true
+```
 
 ### Creating MenuItems
 
@@ -83,10 +91,29 @@ Can be used as a check to see if 'target="_blank"' should be added to links.
 
 ### Usage in template
 
+To loop through a specific MenuSet's items:
+
 	<% loop $MenuSet('YourMenuName').MenuItems %>
 		<a href="$Link" class="$LinkingMode">$MenuTitle</a>
 	<% end_loop %>
 
+To loop through *all* MenuSets and their items:
+
+	<% loop $MenuSets %>
+		<% loop $MenuItems %>
+			<a href="$Link" class="$LinkingMode">$MenuTitle</a>
+		<% end_loop %>
+	<% end_loop %>
+
+Optionally you can also limit the number of MenuSets and MenuItems that are looped through.
+
+The example below will fetch the top 4 MenuSets (as seen in Menu Management), and the top 5 MenuItems for each:
+
+	<% loop $MenuSets.Limit(4) %>
+		<% loop $MenuItems.Limit(5) %>
+			<a href="$Link" class="$LinkingMode">$MenuTitle</a>
+		<% end_loop %>
+	<% end_loop %>
 
 ###Code guidelines
 

--- a/code/MenuAdmin.php
+++ b/code/MenuAdmin.php
@@ -26,4 +26,22 @@ class MenuAdmin extends ModelAdmin
      * @var array
      */
     private static $model_importers = array();
+
+    /**
+     * @param mixed $id
+     * @param mixed $fields
+     * @return ModelAdmin
+     */
+    public function getEditForm($id = null, $fields = null) {
+        $form = parent::getEditForm($id, $fields);
+
+        if (Config::inst()->get($this->modelClass, 'allow_sorting')) {
+            $gridFieldName = $this->sanitiseClassName($this->modelClass);
+            $gridField = $form->Fields()->fieldByName($gridFieldName);
+
+            $gridField->getConfig()->addComponent(new GridFieldOrderableRows());
+        }
+
+        return $form;
+    }
 }

--- a/code/MenuManagerTemplateProvider.php
+++ b/code/MenuManagerTemplateProvider.php
@@ -8,7 +8,8 @@ class MenuManagerTemplateProvider implements TemplateGlobalProvider
     public static function get_template_global_variables()
     {
         return array(
-            'MenuSet' => 'MenuSet'
+            'MenuSet' => 'MenuSet',
+            'MenuSets' => 'MenuSets'
         );
     }
 
@@ -24,5 +25,15 @@ class MenuManagerTemplateProvider implements TemplateGlobalProvider
                     'Name' => $name
                 )
             )->first();
+    }
+
+    /**
+     * @return DataList
+     */
+    public static function MenuSets()
+    {
+        $menuSets = MenuSet::get();
+
+        return $menuSets;
     }
 }

--- a/code/MenuManagerTemplateProvider.php
+++ b/code/MenuManagerTemplateProvider.php
@@ -32,8 +32,6 @@ class MenuManagerTemplateProvider implements TemplateGlobalProvider
      */
     public static function MenuSets()
     {
-        $menuSets = MenuSet::get();
-
-        return $menuSets;
+        return MenuSet::get();
     }
 }

--- a/code/MenuSet.php
+++ b/code/MenuSet.php
@@ -9,7 +9,8 @@ class MenuSet extends DataObject implements PermissionProvider
      * @var array
      */
     private static $db = array(
-        'Name' => 'Varchar(255)'
+        'Name' => 'Varchar(255)',
+        'Sort' => 'Int'
     );
 
     /**
@@ -42,6 +43,11 @@ class MenuSet extends DataObject implements PermissionProvider
             'MANAGE_MENU_SETS' => 'Manage Menu Sets',
         );
     }
+
+    /**
+     * @var string
+     */
+    private static $default_sort = 'Sort';
 
     /**
      * @param mixed $member


### PR DESCRIPTION
I often find it useful to loop through all `MenuSet`s that have been created instead of having to hard code `MenuSet` names into our templates. This is most often the case when we're using the Menu Manager to control a single area of the website. EG: A footer with 4 `MenuSet`s (`Limit(4)`), or a vertical  side nav where we don't mind how many `MenuSet`s the admin creates.

Consequently, if we're looping through `MenuSet`s systematically then it's also useful to allow admins to change the sort order of those sets.

I'm currently achieving this by adding a method to my `SiteConfig` to get all `MenuSet`s (with or without a `Limit()`), but I thought that others might also find this option useful.

Future improvements: Increase visibility in the CMS as to how many `Set/Item`s are being displayed on the frontend (if they are being limited). So far though, I've found it easy enough to just tell the admins "only the top [number] will show in [area]".
