### PR TITLE
Add getTitle function to MenuItem for readable names in CMS

### DIFF
--- a/code/MenuItem.php
+++ b/code/MenuItem.php
@@ -97,6 +97,14 @@ class MenuItem extends DataObject implements PermissionProvider
     }
 
     /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->MenuTitle ? $this->MenuTitle : '#{$this->ID}';
+    }
+
+    /**
      * @return FieldList
      */
     public function getCMSFields()


### PR DESCRIPTION
- the CMS breadcrumbs for MenuItems display #{ID}
- the autocomplete for adding existing MenuItems displays #{ID}
- MenuItems are difficult to identify by ID for users
- This change returns the MenuTitle as the Title when available for CMS functionality that requires it. Otherwise #{ID} is returned.

Below is an example of how adding getTitle effects the display of MenuItems within the CMS: 
![menumanager-title-example](https://user-images.githubusercontent.com/2417969/29953917-f5321140-8f27-11e7-8659-237828e48273.png)
