### PR TITLE
Improved MenuSet canView & canEdit Permissions

### DIFF
--- a/src/MenuSet.php
+++ b/src/MenuSet.php
@@ -86,7 +86,7 @@ class MenuSet extends DataObject implements PermissionProvider
      */
     public function canEdit($member = null)
     {
-        return Permission::check('MANAGE_MENU_SETS');
+        return Permission::check('MANAGE_MENU_SETS') || Permission::check('MANAGE_MENU_ITEMS');
     }
 
     /**
@@ -95,7 +95,7 @@ class MenuSet extends DataObject implements PermissionProvider
      */
     public function canView($member = null)
     {
-        return Permission::check('MANAGE_MENU_SETS');
+        return Permission::check('MANAGE_MENU_SETS') || Permission::check('MANAGE_MENU_ITEMS');
     }
 
     /**


### PR DESCRIPTION
Originally the MANAGE_MENU_**ITEMS** permission was useless unless the user had view and edit permissions on MenuSet (as you can't get to MenuItems without being able to view/edit the MenuSet), but the only way to have this was to also have the MANAGE_MENU_**SETS** permission, which would also allow them to create new MenuSets, a function that should be normally restricted to developers.

This change allows users with the MANAGE_MENU_**ITEMS** permission to view and edit MenuSets, which means you can give normal users the MANAGE_MENU_**ITEMS** permission __only__, which will now allow them add/edit menu items but not create new MenuSets.

Fixes #12