### PR TITLE
Re-add "silverstripe-" prefix to package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "heyday/menumanager",
+	"name": "heyday/silverstripe-menumanager",
 	"type": "silverstripe-vendormodule",
 	"description": "Allows complex menu management to be handled through the CMS when a simple tree structure is not enough.",
 	"license": "MIT",


### PR DESCRIPTION
The change was unnecessary, and Packagist still only recognises `silverstripe-menumanager` anyway - https://packagist.org/packages/heyday/silverstripe-menumanager