### PR TITLE
Delete duplicate default menu sets. Opt-in disable menuset creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,19 @@ the MenuItems associated Page.
 If you enter a link in this field and then pick a Page as well the link will
 be overwritten by the Page you chose.
 
-
 #### IsNewWindow
 Can be used as a check to see if 'target="_blank"' should be added to links.
 
+### Disable creating Menu Sets in the CMS
+
+Sometimes the defined `default_sets` are all the menu's a project needs. You can disable the ability to create new Menu Sets in the CMS:
+
+```yml
+Heyday\MenuManager\MenuAdmin:
+  enable_cms_create: false
+```
+
+_Note: Non-default Menu Sets can still be deleted, to help tidy unwanted CMS content._
 
 ### Usage in template
 

--- a/src/MenuAdmin.php
+++ b/src/MenuAdmin.php
@@ -3,6 +3,9 @@
 namespace Heyday\MenuManager;
 
 use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridFieldImportButton;
 
 /**
  * Class MenuAdmin
@@ -25,7 +28,7 @@ class MenuAdmin extends ModelAdmin
      * @var string
      */
     private static $menu_title = 'Menu Management';
-    
+
     /**
      * @var string
      */
@@ -35,4 +38,34 @@ class MenuAdmin extends ModelAdmin
      * @var array
      */
     private static $model_importers = [];
+
+    /**
+     * @var bool
+     */
+    private static $enable_cms_create = true;
+
+    /**
+     * Adjust the CMS's ability to create MenuSets
+     *
+     * {@inheritDoc}
+     */
+    public function getEditForm($id = null, $fields = null)
+    {
+        $form = parent::getEditForm($id, $fields);
+
+        /** @var GridField $gridField */
+        $gridField = $form->Fields()->dataFieldByName($this->sanitiseClassName(MenuSet::class));
+
+        if ($gridField) {
+            if (!$this->config()->get('enable_cms_create')) {
+                $gridField->getConfig()
+                    ->removeComponentsByType([
+                        GridFieldAddNewButton::class,
+                        GridFieldImportButton::class,
+                    ]);
+            }
+        }
+
+        return $form;
+    }
 }


### PR DESCRIPTION
Site owners/developers can opt-in to disable creation of menu sets
https://github.com/heyday/silverstripe-menumanager/issues/40

Give CMS authors with menu management permissions the ability to delete duplicate default menu sets.
https://github.com/heyday/silverstripe-menumanager/issues/42