### PR TITLE
Add translation support 

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,31 @@
+en:
+  Heyday\MenuManager\MenuAdmin:
+    MENUTITLE: "Menus"
+  Heyday\MenuManager\MenuSet:
+    SINGULARNAME: "Menu Set"
+    PLURALNAME: "Menu Sets"
+    PLURALS:
+      one: "A Menu Set"
+      other: "{count} Menu Sets"
+    DB_Name: "Name"
+    DB_Name_Description: "This field can't be changed once set"
+    ManageMenuSets: "Manage Menu Sets"
+  Heyday\MenuManager\MenuItem:
+    SINGULARNAME: "Menu Item"
+    PLURALNAME: "Menu Items"
+    PLURALS:
+      one: "A Menu Item"
+      other: "{count} Menu Items"
+    Label: "Label"
+    PageTitle: "Page Title"
+    Link: "Link"
+    NewTab: "Opens in a new tab?"
+    DB_MenuTitle: "Link Label"
+    DB_MenuTitle_Description: "If left blank, will default to the selected page's name."
+    DB_PageID: "Page on this site"
+    DB_PageID_Description: "Leave blank if you wish to manually specify the URL below."
+    DB_Link: "URL"
+    DB_Link_Description: "Enter a full URL to link to another website."
+    DB_IsNewWindow: "Open in a new tab?"
+    ManageMenuItems: "Manage Menu Items"
+

--- a/src/MenuAdmin.php
+++ b/src/MenuAdmin.php
@@ -24,12 +24,12 @@ class MenuAdmin extends ModelAdmin
     /**
      * @var string
      */
-    private static $menu_title = 'Menu Management';
+    private static $menu_title = 'Menus';
 
     /**
      * @var string
      */
-    private static $menu_icon_class = 'font-icon-list';
+    private static $menu_icon_class = 'font-icon-link';
 
     /**
      * @var array

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -53,18 +53,13 @@ class MenuItem extends DataObject implements PermissionProvider
     ];
 
     /**
-     * @var array
+     * @return string
      */
-    private static $summary_fields = [
-        'MenuTitle' => 'Title',
-        'Page.Title' => 'Page Title',
-        'Link' => 'Link',
-        'IsNewWindowNice' => 'Opens in new window?'
-    ];
-
     public function IsNewWindowNice()
     {
-        return $this->IsNewWindow ? 'Yes' : 'No';
+        return $this->IsNewWindow
+            ? _t('SilverStripe\\Forms\\CheckboxField.YESANSWER', 'Yes')
+            : _t('SilverStripe\\Forms\\CheckboxField.NOANSWER', 'No');
     }
 
     /**
@@ -78,7 +73,7 @@ class MenuItem extends DataObject implements PermissionProvider
     public function providePermissions()
     {
         return [
-            'MANAGE_MENU_ITEMS' => 'Manage Menu Items'
+            'MANAGE_MENU_ITEMS' => _t(__CLASS__ . '.ManageMenuItems', 'Manage Menu Items')
         ];
     }
 
@@ -129,17 +124,41 @@ class MenuItem extends DataObject implements PermissionProvider
         $fields->addFieldsToTab(
             'Root.main',
             [
-                TextField::create('MenuTitle', 'Link Label')
-                    ->setDescription('If left blank, will default to the selected page\'s name.'),
+                TextField::create(
+                    'MenuTitle',
+                    _t(__CLASS__ . '.DB_MenuTitle', 'Link Label')
+                )->setDescription(
+                    _t(
+                        __CLASS__ . '.DB_MenuTitle_Description',
+                        'If left blank, will default to the selected page\'s name.'
+                    )
+                ),
+
                 TreeDropdownField::create(
                     'PageID',
-                    'Page on this site',
+                    _t(__CLASS__ . '.DB_PageID', 'Page on this site'),
                     SiteTree::class
-                )
-                    ->setDescription('Leave blank if you wish to manually specify the URL below.'),
-                TextField::create('Link', 'URL')
-                    ->setDescription('Enter a full URL to link to another website.'),
-                CheckboxField::create('IsNewWindow', 'Open in a new window?')
+                )->setDescription(
+                    _t(
+                        __CLASS__ . '.DB_PageID_Description',
+                        'Leave blank if you wish to manually specify the URL below.'
+                    )
+                ),
+
+                TextField::create(
+                    'Link',
+                    _t(__CLASS__ . '.DB_Link', 'URL')
+                )->setDescription(
+                    _t(
+                        __CLASS__ . '.DB_Link_Description',
+                        'Enter a full URL to link to another website.'
+                    )
+                ),
+
+                CheckboxField::create(
+                    'IsNewWindow',
+                    _t(__CLASS__ . '.DB_IsNewWindow', 'Open in a new window?')
+                ),
             ]
         );
 
@@ -205,5 +224,15 @@ class MenuItem extends DataObject implements PermissionProvider
         if ($this->PageID != 0) {
             $this->Link = null;
         }
+    }
+
+    public function summaryFields()
+    {
+        return [
+            'MenuTitle' => _t(__CLASS__ . '.Label', 'Label'),
+            'Page.Title' => _t(__CLASS__ . '.PageTitle', 'Page Title'),
+            'Link' => _t(__CLASS__ . '.DB_Link', 'Link'),
+            'IsNewWindowNice' => _t(__CLASS__ . '.NewTab', 'Opens in a new tab?'),
+        ];
     }
 }

--- a/src/MenuSet.php
+++ b/src/MenuSet.php
@@ -46,19 +46,12 @@ class MenuSet extends DataObject implements PermissionProvider
     ];
 
     /**
-     * @var array
-     */
-    private static $summary_fields = [
-        'Name'
-    ];
-
-    /**
      * @return array
      */
     public function providePermissions()
     {
         return [
-            'MANAGE_MENU_SETS' => 'Manage Menu Sets',
+            'MANAGE_MENU_SETS' => _t(__CLASS__ . '.ManageMenuSets', 'Manage Menu Sets'),
         ];
     }
 
@@ -162,7 +155,15 @@ class MenuSet extends DataObject implements PermissionProvider
         } else {
             $fields->addFieldToTab(
                 'Root.Main',
-                new TextField('Name', 'Name (this field can\'t be changed once set)')
+                TextField::create(
+                    'Name',
+                    _t(__CLASS__ . '.DB_Name', 'Name')
+                )->setDescription(
+                    _t(
+                        __CLASS__ . '.DB_Name_Description',
+                        'This field can\'t be changed once set'
+                    )
+                )
             );
         }
 
@@ -192,5 +193,15 @@ class MenuSet extends DataObject implements PermissionProvider
     protected function getDefaultSetNames()
     {
         return $this->config()->get('default_sets') ?: [];
+    }
+
+    /**
+     * @return array
+     */
+    public function summaryFields()
+    {
+        return [
+            'Name' => _t(__CLASS__ . '.DB_Name', 'Name')
+        ];
     }
 }


### PR DESCRIPTION
Fixes #2 

- Allows CMS interface to be translated into multiple languages
- Added `en.yml` as a starting point
- Minor rewordings:
  - 'Open in a new window' becomes 'Open in a new tab' - keeping up with the times
  - 'Menu Management' becomes 'Menus' for brevity and consistency
- Updated menu icon



As it appears in the CMS:

![Screen Shot 2021-03-04 at 23 20 52](https://user-images.githubusercontent.com/2873649/109949521-52796b00-7d40-11eb-9a06-8dfbb2a71969.png)