### PR TITLE
FIX integration issues with Subsites

### DIFF
--- a/src/MenuManagerTemplateProvider.php
+++ b/src/MenuManagerTemplateProvider.php
@@ -2,11 +2,15 @@
 
 namespace Heyday\MenuManager;
 
-use SilverStripe\ORM\DataObject;
+use InvalidArgumentException;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\View\TemplateGlobalProvider;
 
 class MenuManagerTemplateProvider implements TemplateGlobalProvider
 {
+    use Extensible;
+
     /**
      * @return array
      */
@@ -19,15 +23,27 @@ class MenuManagerTemplateProvider implements TemplateGlobalProvider
 
     /**
      * @param $name
-     * @return DataObject
+     * @return MenuSet|null
      */
     public static function MenuSet($name)
     {
-        return MenuSet::get()
-            ->filter(
-                [
-                    'Name' => $name
-                ]
-            )->first();
+        return Injector::inst()->get(self::class)->findMenuSetByName($name);
+    }
+
+    /**
+     * Find a MenuSet by name
+     *
+     * @param string $name
+     * @return MenuSet|null
+     * @throws InvalidArgumentException
+     */
+    public function findMenuSetByName($name)
+    {
+        if (empty($name)) {
+            throw new InvalidArgumentException("Please pass in the name of the MenuSet you're trying to find");
+        }
+        $result = MenuSet::get()->filter('Name', $name);
+        $this->extend('updateFindMenuSetByName', $result);
+        return $result->first();
     }
 }


### PR DESCRIPTION
via [guttmann/silverstripe-menumanager-subsites](https://github.com/guttmann/silverstripe-menumanager-subsites) one can use the
Menu Manager module while keeping menus segregated by Subsite and
managable by each. However on dev/build the configured default
menus (see MenuSet::requireDefaultRecords) error each time, as the
system attempts to create the same menus for each subsite. Since
fd5caf63e9d5e789ae7ca9c6adca5f893564266c the system sees that a
menu by the given name is already in the database (without
filtering by subsite) and throws an emergency validation error,
halting the dev/build from completing properly.

The validation issue itself was brought in to handle an issue
where duplicate entries in the database could not be cleared out
via usage of the CMS. We should instead consider adding extension
hooks to allow sub-modules as such to alter the filters used to
find a MenuSet by a given name.

Related: https://github.com/guttmann/silverstripe-menumanager-subsites/pull/9